### PR TITLE
Rock960: updated documentation for alternative way to manually pressing maskrom mode button

### DIFF
--- a/consumer/rock/installation/linux-upgrade_tool.md
+++ b/consumer/rock/installation/linux-upgrade_tool.md
@@ -76,7 +76,7 @@ It contains the following partitions:
 
 - power on rock960
 - plug the rock960 to Linux desktop with USB type A to type C cable
-- press and hold the maskrom key, then short press reset key
+- press and hold the maskrom key, then short press reset key (alternatively, reboot the device to loader mode `adb reboot bootloader` then use the upgrade_tool to reset the device into maskrom mode `upgrade_tool rd 3`).
 
 On the host PC, `lsusb` should show the following VID/PID if the board is in maskrom mode: `Bus 003 Device 061: ID 2207:0011`
 


### PR DESCRIPTION
update to rock960 documentation - alternative way for the manually  pressing the maskrom button, this is critical for automated scripting while working with the module. Also I haven't found documentation for the resetting modes of rockchip.  